### PR TITLE
clarifications for early testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Relies on [`mmap-io`](https://github.com/ozra/mmap-io) for JS implementation of 
 
 # Usage
 
-```
+```js
 const { PyShell, PyRepl, PyScope } = require("pyrepl/pyrepl");
 
 async function main() {

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ npm test
 * Tests and demos known to work on Linux and Windows. On Windows, you may find [Windows Build Tools](https://www.npmjs.com/package/windows-build-tools) useful.
 * Untested on macOS (let me know if you test it and it works)
 * Many of the devDependencies packages are only needed for demos, eg, `lodash.throttle`, `electron`and`electron-rebuild`.
-* If you're testing on MacOS and get a `node-gyp` error during installation due to a `python` version issue, try using the MacOS default python using `npm config set python /usr/bin/python`
+* If getting a `node-gyp` error during installation on macOS due to a `python` version issue try using the macOS default python using `npm config set python /usr/bin/python`

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ npm test
 * Tests and demos known to work on Linux and Windows. On Windows, you may find [Windows Build Tools](https://www.npmjs.com/package/windows-build-tools) useful.
 * Untested on macOS (let me know if you test it and it works)
 * Many of the devDependencies packages are only needed for demos, eg, `lodash.throttle`, `electron`and`electron-rebuild`.
+* If you're testing on MacOS and get a `node-gyp` error during installation due to a `python` version issue, try using the MacOS default python using `npm config set python /usr/bin/python`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ npm test
 
 # Good to Know / Known Issues
 
-* Tests and demos known to work on Linux and Windows. On Windows, you may find [Windows Build Tools](https://www.npmjs.com/package/windows-build-tools) useful.
-* The `simple.js` demo has additionally been tested on macOS
-* Many of the devDependencies packages are only needed for demos, eg, `lodash.throttle`, `electron`and`electron-rebuild`.
+* Tests and demos known to work on Linux, Windows, and macOS. On Windows, you may find [Windows Build Tools](https://www.npmjs.com/package/windows-build-tools) useful.
+* Many of the devDependencies packages are only needed for demos, eg, `lodash.throttle`, `electron`, and`electron-rebuild`.
 * If getting a `node-gyp` error during installation on macOS due to a `python` version issue try using the macOS default python using `npm config set python /usr/bin/python`

--- a/README.md
+++ b/README.md
@@ -61,11 +61,25 @@ See `__tests__` for more examples.
 
 # Demos
 
-_Note_: pyrepl depends on mmap-io, which is a node extension module (dynamically loaded shared library). This package must be built for individually for each node and electron version. When installed, it will automatically build against the system installed node version. You can use the `electron-rebuild` NPM script to rebuild it for the installed electron version, or `npm rebuild` to rebuild for the installed node version.
+Two demos are included:
 
-* **simple.js**: Node demo showing basic functionality. To run: `node demos/node/simple.js`
-* **filter**: demonstrates embedding in a simple single-page web app. Because PyRepl depends on local inter-process communication, this example will only run within Electron. To run:
-  `node_modules/.bin/electron demos/electron/filter`
+- **`simple.js`** shows basic functionality
+- **`filter`** demonstrates embedding in a single-page web app in Electron
+
+To run the simple demo, first install the dependencies for both `node` and `python` by cloning this repo and running the following commands from inside the top-level directory
+
+- `npm install`
+- `pip install -r requirements.txt`
+
+Then run the demo with
+
+`node demos/node/simple.js`
+
+To run the `filter` demo call
+
+`node_modules/.bin/electron demos/electron/filter`
+
+_Note_: pyrepl depends on mmap-io, which is a node extension module (dynamically loaded shared library). This package must be built for individually for each node and electron version. When installed, it will automatically build against the system installed node version. You can use the `electron-rebuild` NPM script to rebuild it for the installed electron version, or `npm rebuild` to rebuild for the installed node version.
 
 # Tests
 
@@ -76,6 +90,6 @@ npm test
 # Good to Know / Known Issues
 
 * Tests and demos known to work on Linux and Windows. On Windows, you may find [Windows Build Tools](https://www.npmjs.com/package/windows-build-tools) useful.
-* Untested on macOS (let me know if you test it and it works)
+* The `simple.js` demo has additionally been tested on macOS
 * Many of the devDependencies packages are only needed for demos, eg, `lodash.throttle`, `electron`and`electron-rebuild`.
 * If getting a `node-gyp` error during installation on macOS due to a `python` version issue try using the macOS default python using `npm config set python /usr/bin/python`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+llist
+bson


### PR DESCRIPTION
Various tweaks to the README after doing an initial test run on macOS. Mainly clarifying the installation instructions and Python dependencies.